### PR TITLE
revert to gradle 2.0.0, eliminate conflicting dependencies most notab…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         classpath 'me.tatarka:gradle-retrolambda:3.2.5'
     }
 }

--- a/fitpay/build.gradle
+++ b/fitpay/build.gradle
@@ -28,6 +28,10 @@ android {
     }
 }
 
+configurations.all {
+    resolutionStrategy.failOnVersionConflict()
+}
+
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
@@ -35,22 +39,34 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.3.0'
 
     compile 'com.squareup.retrofit2:retrofit:2.0.0-beta4'
+
     compile 'com.squareup.retrofit2:converter-gson:2.0.0-beta4'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.1.2'
+    compile ('com.squareup.okhttp3:logging-interceptor:3.1.2') {
+        exclude module: 'okhttp'
+    }
 
     compile 'org.bouncycastle:bcprov-jdk15on:1.54'
     compile 'com.nimbusds:nimbus-jose-jwt:4.12'
 
-    compile 'com.pusher:pusher-java-client:1.0.2'
+    compile ('com.pusher:pusher-java-client:1.0.2') {
+        exclude module: 'gson'
+    }
 
     compile 'com.github.orhanobut:logger:1.12'
 
     compile 'io.reactivex:rxjava:1.1.2'
-    compile 'io.reactivex:rxandroid:1.1.0'
+    compile ('io.reactivex:rxandroid:1.1.0') {
+        exclude module: 'rxjava'
+    }
 
     compile 'me.alexrs:prefs:1.1.0'
 
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile "org.robolectric:robolectric:3.0"
+    testCompile ('org.mockito:mockito-core:1.10.19') {
+        exclude module: 'hamcrest-core'
+    }
+    testCompile ('org.robolectric:robolectric:3.0') {
+        exclude module: 'junit'
+        exclude group: 'org.bouncycastle'
+    }
     testCompile 'junit:junit:4.12'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Tue Apr 19 11:07:17 MDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
Vlad,
When trying to run tests I ran into conficting jar load for bouncy castle which generated NoSuchMethod classloader issues.   To resolve these I explicitly eliminated duplicate dependendency loading via gradle 'excludes'.   Since I am relatively new to gradle, I look to you to define best practices so that jar dependencies are gracefully resolved.  Your feedback is appreciated 